### PR TITLE
Fixed .pyf file to include python_callback info to FORTRAN_CALLER.

### DIFF
--- a/minimal_fortran.pyf
+++ b/minimal_fortran.pyf
@@ -13,13 +13,16 @@ end python module xerbla__user__routines
 python module minimal_fortran ! in 
     interface  ! in :minimal_fortran
         subroutine xerbla(srname,info) ! in :minimal_fortran:XERBLA.f
-            use xerbla__user__routines
+            use xerbla__user__routines, python_callback=>python_callback
             character*(*) :: srname
             integer :: info
             intent(callback) python_callback
             external python_callback
         end subroutine xerbla
         subroutine fortran_caller(a1) ! in :minimal_fortran:FORTRAN_CALLER.f
+            use xerbla__user__routines, python_callback=>python_callback
+            intent(callback, hide) python_callback
+            external python_callback
             integer :: a1
         end subroutine fortran_caller
     end interface 


### PR DESCRIPTION
Hi @bnavigator !

I hope this helps. The problem (as explained in https://github.com/numpy/numpy/issues/16277) is that `FORTRAN_CALLER` needs to know about `python_callback` too, even though it doesn't call it directly (because since f2py doesn't call `XERBLA` directly, it has no way of getting that interface unless it's explicitly written in the `pyf` file).

Feel free to reach out if you have any further problems.